### PR TITLE
Add auto-generated Eclipse files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /bin
 .classpath
 .project
+.settings

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 /.idea
 /.vscode
 /out
+
+# Eclipse
+/bin
+.classpath
+.project

--- a/src/com/jagex/runescape/Client.java
+++ b/src/com/jagex/runescape/Client.java
@@ -7233,7 +7233,7 @@ public final class Client extends RSApplet {
             }
             this.jaggrabSocket = null;
         }
-        this.jaggrabSocket = this.openSocket(43595);
+        this.jaggrabSocket = this.openSocket(Constants.PORT);
         this.jaggrabSocket.setSoTimeout(10000);
         final java.io.InputStream inputstream = this.jaggrabSocket.getInputStream();
         final OutputStream outputstream = this.jaggrabSocket.getOutputStream();


### PR DESCRIPTION
This PR also replaces usage of a magic number for the server port.